### PR TITLE
Relay /home/?code=xxx to the active server

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -110,3 +110,12 @@ follow us on [Twitter], [YouTube], or [Facebook].
 [Twitter]: https://twitter.com/wwtelescope
 [YouTube]: https://www.youtube.com/c/AASWorldWideTelescope
 [Facebook]: https://facebook.com/wwtelescope
+
+
+<script>
+// Helper for the Microsoft Live OAuth workflow.
+let code = new URLSearchParams(window.location.search).get('code');
+if (code) {
+  window.location.href = '/LiveId/AuthenticateFromCode/' + encodeURI(code) + '?returnUrl=%2Fhome%2F';
+}
+</script>


### PR DESCRIPTION
This comes up in the Communities OAuth login flow. I don't expect this to fix the login issues, and to be honest I'm not sure that this redirect will completely reproduce the old semantics, but it should help as a stopgap.