### PR TITLE
Update the beta download page

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@
 
 parameters:
 - name: 'zolaVersion'
-  default: '0.10.1'
+  default: '0.15.2'
   type: string
 
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,8 @@ jobs:
   #   displayName: Check site
 
   - script: |
-      ./zola build -o $(build.artifactStagingDirectory)
+      # The "echo" gets past a Zola confirmation to blow away the output directory
+      echo y |./zola build -o $(build.artifactStagingDirectory)
     displayName: Build site
 
   - task: PublishPipelineArtifact@0

--- a/content/about/acknowledgments.md
+++ b/content/about/acknowledgments.md
@@ -101,7 +101,7 @@ these organizations:
 [ipac]: http://www.ipac.caltech.edu/
 [ivoa]: http://www.ivoa.net/
 [nasa]: https://www.nasa.gov/
-[noirlab]: https://nationalastro.org/
+[noirlab]: https://noirlab.edu/
 [princeton]: https://web.astro.princeton.edu/
 [usno]: https://en.wikipedia.org/wiki/United_States_Naval_Observatory
 [vamp]: https://virtualastronomy.org/

--- a/content/download/_index.md
+++ b/content/download/_index.md
@@ -22,42 +22,24 @@ If you want to use WWT from Python, find installation instructions for
 </section>
 
 
-# AAS WorldWide Telescope 6.0 Beta for Windows {#windows-client}
+# AAS WorldWide Telescope for Windows: Version 6 Beta {#windows-client}
 
-WorldWide Telescope 6.0 Beta is the latest version of AAS WorldWide Telescope
-(WWT). This feature-rich application is now available to everyone as a free
-download.
+We recommend that most users install the WWT Version 6 Beta, which provides the
+latest features and data updates.
 
-{{ bigbutton(text="Download WWT 6.0.11 Beta", url="https://wwtweb.blob.core.windows.net/drops/wwtsetup.6.0.11.msi") }}
+{{ bigbutton(text="Install the Beta", url="./beta/") }}
 
-WWT 6.0 Beta runs on Windows 7/8/8.1/10, in either 32- or 64-bit mode,
-depending on your operating system. It also supports native DirectX 11,
-DirectX 10, and has some support for down-level DirectX 9 hardware running
-through the DirectX 11 API.
-
-### Minimum System Requirements
-
-- Windows 7/8/8.1/10 (older versions of Windows are not supported)
-- Intel 5th generation (Broadwell) or 6th generation (Skylake) Core i CPU
-- 4 GB system memory
-- Intel Integrated graphics associated with 5th generation (Broadwell) or 6th
-  generation (Skylake) chipsets
-
-### Recommended System Requirements
-
-- Intel 5th generation (Broadwell) or 6th generation (Skylake) Core i7 CPU
-- 8+ GB system memory
-- Discrete graphics card with 1+ GB VRAM, DirectX 10 or DirectX 11
-  compatibility, such as NVIDIA GTX 480 or ATI Radeon HD 5850 or better.
-
-Do not attempt to install WWT 5.0 or higher on Windows XP. It will not run and
-can potentially prevent the legacy version from running.
+If you have a “production” installation of WWT, such as a planetarium or museum
+kiosk, **do not install the beta version in your production system without
+significant advance testing.** While the WWT team strives to keep the Windows
+application functioning as reliably as possible, the latest version of WWT
+includes internal changes that may break existing use cases.
 
 
-# AAS WorldWide Telescope 5.5 for Windows
+# WWT for Windows: Version 5 Series
 
-WorldWide Telescope 5.5 is the most recent stable version of AAS WorldWide
-Telescope (WWT).
+The previous stable version of AAS WorldWide Telescope is the Version 5 series.
+The most recent release is version 5.5.03 (July, 2016).
 
 {{ bigbutton(text="Download WWT 5.5.03", url="https://wwtweb.blob.core.windows.net/drops/WWTSetup.5.5.03.msi") }}
 

--- a/content/download/_index.md
+++ b/content/download/_index.md
@@ -24,24 +24,25 @@ If you want to use WWT from Python, find installation instructions for
 
 # AAS WorldWide Telescope for Windows: Version 6 Beta {#windows-client}
 
-We recommend that most users install the WWT Version 6 Beta, which provides the
-latest features and data updates.
+If you want to install the WWT Windows application, you should most likely
+install the WWT Version 6 Beta, which provides the latest features and data
+updates:
 
 {{ bigbutton(text="Install the Beta", url="./beta/") }}
 
-If you have a “production” installation of WWT, such as a planetarium or museum
-kiosk, **do not install the beta version in your production system without
-significant advance testing.** While the WWT team strives to keep the Windows
-application functioning as reliably as possible, the latest version of WWT
-includes internal changes that may break existing use cases.
+However, if you have a “production” installation of WWT, such as a planetarium
+or museum kiosk, **do not install the beta version in your production system
+without significant advance testing.** While the WWT team strives to keep the
+Windows application functioning as reliably as possible, the latest version of
+WWT includes internal changes that may break existing use cases.
 
 
 # WWT for Windows: Version 5 Series
 
 The previous stable version of AAS WorldWide Telescope is the Version 5 series.
-The most recent release is version 5.5.03 (July, 2016).
+The most recent release is version 5.5.3 (July, 2016).
 
-{{ bigbutton(text="Download WWT 5.5.03", url="https://wwtweb.blob.core.windows.net/drops/WWTSetup.5.5.03.msi") }}
+{{ bigbutton(text="Download WWT 5.5.3", url="https://web.wwtassets.org/releases/wwt/wwtsetup-5.5.3.msi") }}
 
 WWT 5.5 runs on Windows 7/8/8.1/10, in either 32- or 64-bit mode, depending on
 your operating system. It also supports native DirectX 11, DirectX 10, and has
@@ -73,8 +74,8 @@ The WWT Remote Control is a Windows utility that assists with remotely
 operating the main WWT application, especially in cluster environments as
 found in planetariums.
 
-- [Download WWTRemote 5.0](http://wwtweb.blob.core.windows.net/drops/WWTRemote.5.0.0.msi)
-- [Download WWTRemote 2.1.1 Legacy](http://wwtweb.blob.core.windows.net/drops/WWTRemote.2.1.1.msi)
+- [Download WWTRemote 5.0.0](http://web.wwtassets.org/releases/remote/wwtremote-5.0.0.msi)
+- [Download WWTRemote 2.1.1 Legacy](http://web.wwtassets.org/releases/remote/wwtremote-2.1.1.msi)
 
 
 # WWT Add-in for Excel (Windows only) {#excel-addin}
@@ -82,16 +83,16 @@ found in planetariums.
 The WWT Excel add-in enables Windows users to efficiently highlight, organize,
 and import their data into the AAS WorldWide Telescope visualization
 environment using the familiar capabilities of Microsoft Excel.
-[Download the WWT Excel Add-in](https://wwtweb.blob.core.windows.net/drops/WWTExcelAddin.msi).
+[Download the WWT Excel Add-in 1.0](http://web.wwtassets.org/releases/exceladdin/wwtexceladdin-1.0.msi).
 
 
 # WorldWide Telescope Legacy (3.1) for Windows XP and Vista
 
-The WorldWide Telescope legacy version (WWT 3.1) supports Windows XP, Windows
+The WorldWide Telescope legacy version (WWT 3.1; May 2015) supports Windows XP, Windows
 Vista, and DirectX 9.0c hardware running as a 32-bit application. Do not
 attempt to install WWT 5.0+ on Windows XP: it will not run and can potentially
 prevent the legacy version from running.
-[Download WWT Legacy 3.1.52](https://wwtweb.blob.core.windows.net/drops/WWTSetup.Legacy.3.1.52.msi).
+[Download WWT Legacy 3.1.52](https://web.wwtassets.org/releases/wwt/wwtsetup-3.1.52.msi).
 
 To run this software, you’ll need the following:
 

--- a/content/download/beta.md
+++ b/content/download/beta.md
@@ -1,7 +1,62 @@
 +++
-template = "redirect.html"
+date = 2022-01-03
+title = "WWT Downloads: Registered Beta"
 aliases = ["/Download/Beta"]
 
 [extra]
-dest_url = "/download/"
+titlebox_class = "background-19036"
 +++
+
+Thank you for your interest in helping beta-test the next version of AAS
+WorldWide Telescope for Windows! The latest beta release version is
+**6.0.901.0** (Dec 29, 2021; [technical changelog][cl]).
+
+[cl]: https://github.com/WorldWideTelescope/wwt-windows-client/blob/release/WWTExplorer3d/CHANGELOG.md
+
+
+# Read This First
+
+First, some disclaimers for “production” installations of WWT, such as
+planetariums and kiosks:
+
+- While the WWT team strives to keep the Windows application functioning as
+  reliably as possible, the latest version of WWT includes internal changes that
+  may break existing use cases. **Do not install the newest version in
+  production scenarios without significant advance testing.**
+- Likewise, the WWT team provides user support on a best-effort basis. We aspire
+  to provide a high level of service but *cannot* guarantee timely technical
+  assistance.
+- If you have any questions about this, contact the team at <a
+  href="mailto:wwt@aas.org">wwt@aas.org</a>.
+
+
+# Signup and Download
+
+Everybody is welcome to beta-test the next version of WWT! To help us understand
+who's interested in WWT for Windows and send you updates about the beta-testing
+process, we ask that you sign up as a beta-tester using the form below. After
+you submit the form, you'll be given a link to download the beta installer.
+
+<iframe
+  src="https://docs.google.com/forms/d/e/1FAIpQLScKug_Y7Y30AMBpQX3gSubXQYxZNEKxnwkr3vy7xDHSX8Lv3w/viewform?embedded=true"
+  width="768" height="720" frameborder="0" marginheight="0" marginwidth="0">Loading …</iframe>
+
+If you lose the link or have any issues using it, just send an email to <a
+  href="mailto:wwt@aas.org">wwt@aas.org</a>.
+
+
+# System Requirements
+
+The latest version of WWT runs on Windows 7/8/8.1/10/11, in either 32- or 64-bit
+mode. It supports native DirectX 10 and 11, and has some support for down-level
+DirectX 9 hardware running through the DirectX 11 API.
+
+Do not attempt to install recent versions of WWT on operating systems older than
+Windows 7. It will not run and can potentially prevent the legacy version from
+running.
+
+### Recommended System Requirements
+
+- Any recent CPU
+- 8+ GB system memory
+- Discrete GPU with 1+ GB VRAM and DirectX 11 compatibility

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,142 +1,151 @@
 {%- import "macros.html" as macros -%}
 {# Jumping through hoops to get a relative path to the site root #}
 {%- if current_path == "/" -%}
-  {%- set_global rel_top = "./" -%}
+{%- set_global rel_top = "." -%}
 {%- else -%}
-  {%- set_global rel_top_work = [] -%}
-  {%- for _ignored in current_path | split(pat="/") | slice(start=1) -%}
-    {%- set_global rel_top_work = rel_top_work | concat(with="..") -%}
-  {%- endfor -%}
-  {%- set_global rel_top = rel_top_work | join(sep="/") -%}
-  {%- set_global rel_top = rel_top ~ "/" -%}
+{%- set_global rel_top_work = [] -%}
+{%- for _ignored in current_path | trim_end_matches(pat="/") | split(pat="/") | slice(start=1) -%}
+{%- set_global rel_top_work = rel_top_work | concat(with="..") -%}
+{%- endfor -%}
+{%- set_global rel_top = rel_top_work | join(sep="/") -%}
 {%- endif -%}
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="content-type" content="text/html; charset=utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-    <title>{% block title %}{{ config.title }}{% endblock title %}</title>
 
-    {% if config.extra.google_analytics_id %}
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.extra.google_analytics_id }}"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', '{{ config.extra.google_analytics_id }}');
-    </script>
-    {% endif %}
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+  <title>{% block title %}{{ config.title }}{% endblock title %}</title>
 
-    <script>
-      // Azure Storage static websites don't redirect directories to trailing
-      // slashes: if the file `foo/bar/index.html` exists, requests to
-      // `foo/bar` will be treated equivalent to `foo/bar/` and
-      // `foo/bar/index.html`, even though this breaks relative URL
-      // resolution. Zola only emits index.html files, so if we're being
-      // loaded and our path doesn't look like one of the latter two forms, we
-      // can be confident that we should redirect. There might be a flash of
-      // broken content but it will hopefully be brief.
-      if (window.location.pathname.indexOf("/", window.location.pathname.length - 1) === -1 &&
-          window.location.pathname.indexOf(".html", window.location.pathname.length - 5) === -1) {
-        window.location.pathname = window.location.pathname + "/";
-      }
-    </script>
+  {% if config.extra.google_analytics_id %}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.extra.google_analytics_id }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', '{{ config.extra.google_analytics_id }}');
+  </script>
+  {% endif %}
 
-    <link rel="stylesheet" href="{{ rel_top ~ 'assets/fontawesome.min.css' | safe }}">
-    <link rel="stylesheet" href="{{ rel_top ~ 'style.css' | safe }}">
-    <!--[if IE]> <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
-    {% block extra_head %}
-    {% endblock extra_head %}
-  </head>
+  <script>
+    // Azure Storage static websites don't redirect directories to trailing
+    // slashes: if the file `foo/bar/index.html` exists, requests to
+    // `foo/bar` will be treated equivalent to `foo/bar/` and
+    // `foo/bar/index.html`, even though this breaks relative URL
+    // resolution. Zola only emits index.html files, so if we're being
+    // loaded and our path doesn't look like one of the latter two forms, we
+    // can be confident that we should redirect. There might be a flash of
+    // broken content but it will hopefully be brief.
+    if (window.location.pathname.indexOf("/", window.location.pathname.length - 1) === -1 &&
+      window.location.pathname.indexOf(".html", window.location.pathname.length - 5) === -1) {
+      window.location.pathname = window.location.pathname + "/";
+    }
+  </script>
 
-  <body>
-    <header>
-      <nav class="maxwidth">
-        <a href="{{ macros::page_url(rel_top=rel_top, path='home.md') }}">
-          <img class="header-logo" src="{{ rel_top ~ 'assets/wwt-logomark.png' | safe }}">
+  <link rel="stylesheet" href="{{ rel_top ~ '/assets/fontawesome.min.css' | safe }}">
+  <link rel="stylesheet" href="{{ rel_top ~ '/style.css' | safe }}">
+  <!--[if IE]> <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+  {% block extra_head %}
+  {% endblock extra_head %}
+</head>
+
+<body>
+  <header>
+    <nav class="maxwidth">
+      <a href="{{ macros::page_url(rel_top=rel_top, path='home.md') }}">
+        <img class="header-logo" src="{{ rel_top ~ '/assets/wwt-logomark.png' | safe }}">
+      </a>
+
+      <div id="topnav">
+        <i class="fa fa-bars" id="mobile-nav-menu-button"></i>
+
+        <ul>
+          <li class="nav-dropdown-container">
+            <a class="nav-link">About</a><i class="fa fa-caret-down"></i>
+            <ul class="nav-dropdown">
+              <li><a href="{{ macros::section_url(rel_top=rel_top, path='about/_index.md') }}">About WWT</a></li>
+              <li><a href="{{ macros::page_url(rel_top=rel_top, path='about/governance.md') }}">Governance</a></li>
+              <li><a href="{{ macros::page_url(rel_top=rel_top, path='about/acknowledgments.md') }}">Acknowledgments</a>
+              </li>
+              <li><a href="{{ macros::page_url(rel_top=rel_top, path='terms.md') }}">Terms of Use</a></li>
+            </ul>
+          </li>
+          <li class="nav-dropdown-container">
+            <a class="nav-link">Using WWT</a><i class="fa fa-caret-down"></i>
+            <ul class="nav-dropdown">
+              <li><a href="{{ macros::page_url(rel_top=rel_top, path='use/researchers.md') }}">For Research</a></li>
+              <li><a href="{{ macros::page_url(rel_top=rel_top, path='use/educators.md') }}">In the Classroom</a></li>
+              <li><a href="{{ macros::page_url(rel_top=rel_top, path='use/planetariums.md') }}">In Planetariums</a></li>
+              <li><a href="{{ macros::page_url(rel_top=rel_top, path='use/everyone/index.md') }}">For Fun!</a></li>
+            </ul>
+          </li>
+          <li>
+            <a href="{{ macros::section_url(rel_top=rel_top, path='learn/_index.md') }}">Learn More</a>
+          </li>
+          <li>
+            <a href="{{ macros::section_url(rel_top=rel_top, path='download/_index.md') }}">Download</a>
+          </li>
+          <li>
+            <a href="{{ macros::page_url(rel_top=rel_top, path='connect.md') }}">Connect</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  </header>
+
+  {% block full_width_content %}
+  {% endblock full_width_content %}
+
+  <div class="maxwidth">
+    <main class="content">
+      {% block content %}
+      {% endblock content %}
+    </main>
+
+    <footer>
+      <div id="footer-top">
+        <p>Copyright {{ now() | date(format="%Y") }}
+          <a href="https://aas.org/">AAS</a>. HTML generated
+          with <a href="https://www.getzola.org/">Zola</a>.
+          <a href="{{ config.extra.github_url | safe }}">Source code</a>.
+        </p>
+
+        <a class="footer-icon" href="https://bit.ly/wwt-signup" title="Newsletter Signup"
+          aria-label="Newsletter Signup">
+          <i class="fa fa-envelope"></i>
         </a>
 
-        <div id="topnav">
-          <i class="fa fa-bars" id="mobile-nav-menu-button"></i>
+        <a class="footer-icon" href="{{config.extra.twitter_url | safe}}" title="Twitter" aria-label="Twitter">
+          <i class="fa fa-twitter"></i>
+        </a>
 
-          <ul>
-            <li class="nav-dropdown-container">
-              <a class="nav-link">About</a><i class="fa fa-caret-down"></i>
-              <ul class="nav-dropdown">
-                <li><a href="{{ macros::section_url(rel_top=rel_top, path='about/_index.md') }}">About WWT</a></li>
-                <li><a href="{{ macros::page_url(rel_top=rel_top, path='about/governance.md') }}">Governance</a></li>
-                <li><a href="{{ macros::page_url(rel_top=rel_top, path='about/acknowledgments.md') }}">Acknowledgments</a></li>
-                <li><a href="{{ macros::page_url(rel_top=rel_top, path='terms.md') }}">Terms of Use</a></li>
-              </ul>
-            </li><li class="nav-dropdown-container">
-              <a class="nav-link">Using WWT</a><i class="fa fa-caret-down"></i>
-              <ul class="nav-dropdown">
-                <li><a href="{{ macros::page_url(rel_top=rel_top, path='use/researchers.md') }}">For Research</a></li>
-                <li><a href="{{ macros::page_url(rel_top=rel_top, path='use/educators.md') }}">In the Classroom</a></li>
-                <li><a href="{{ macros::page_url(rel_top=rel_top, path='use/planetariums.md') }}">In Planetariums</a></li>
-                <li><a href="{{ macros::page_url(rel_top=rel_top, path='use/everyone/index.md') }}">For Fun!</a></li>
-              </ul>
-            </li><li>
-              <a href="{{ macros::section_url(rel_top=rel_top, path='learn/_index.md') }}">Learn More</a>
-            </li><li>
-              <a href="{{ macros::section_url(rel_top=rel_top, path='download/_index.md') }}">Download</a>
-            </li><li>
-              <a href="{{ macros::page_url(rel_top=rel_top, path='connect.md') }}">Connect</a>
-            </li>
-          </ul>
-        </div>
-      </nav>
-    </header>
+        <a class="footer-icon" href="{{config.extra.github_url | safe}}" title="Git repository"
+          aria-label="Git repository">
+          <i class="fa fa-github"></i>
+        </a>
 
-    {% block full_width_content %}
-    {% endblock full_width_content %}
+        <a class="footer-icon" href="{{config.extra.youtube_url | safe}}" title="YouTube channel"
+          aria-label="YouTube channel">
+          <i class="fa fa-youtube-square"></i>
+        </a>
 
-    <div class="maxwidth">
-      <main class="content">
-        {% block content %}
-        {% endblock content %}
-      </main>
+        <a class="footer-icon" href="{{config.extra.facebook_url | safe}}" title="Facebook" aria-label="Facebook">
+          <i class="fa fa-facebook"></i>
+        </a>
+      </div>
 
-      <footer>
-        <div id="footer-top">
-          <p>Copyright {{ now() | date(format="%Y") }}
-            <a href="https://aas.org/">AAS</a>. HTML generated
-            with <a href="https://www.getzola.org/">Zola</a>.
-            <a href="{{ config.extra.github_url | safe }}">Source code</a>.
-          </p>
+      <p id="footer-logo-text">The AAS WorldWide Telescope project has been supported by:</p>
 
-          <a class="footer-icon" href="https://bit.ly/wwt-signup" title="Newsletter Signup" aria-label="Newsletter Signup">
-            <i class="fa fa-envelope"></i>
-          </a>
+      <div id="logos">
+        <img class="footer-logo" src="{{ rel_top ~ '/assets/aas-publishing-71582561158855.png' }}">
+        <img class="footer-logo" src="{{ rel_top ~ '/assets/nsf-logo-white.png' }}">
+        <img class="footer-logo" src="{{ rel_top ~ '/assets/dotnetfoundationhorizontal.svg' }}">
+        <img class="footer-logo" src="{{ rel_top ~ '/assets/moore-logo-white.png' }}">
+        <img class="footer-logo" src="{{ rel_top ~ '/assets/microsoft-dark.png' }}">
+      </div>
+    </footer>
+  </div>
+</body>
 
-          <a class="footer-icon" href="{{config.extra.twitter_url | safe}}" title="Twitter" aria-label="Twitter">
-            <i class="fa fa-twitter"></i>
-          </a>
-
-          <a class="footer-icon" href="{{config.extra.github_url | safe}}" title="Git repository" aria-label="Git repository">
-            <i class="fa fa-github"></i>
-          </a>
-
-          <a class="footer-icon" href="{{config.extra.youtube_url | safe}}" title="YouTube channel" aria-label="YouTube channel">
-            <i class="fa fa-youtube-square"></i>
-          </a>
-
-          <a class="footer-icon" href="{{config.extra.facebook_url | safe}}" title="Facebook" aria-label="Facebook">
-            <i class="fa fa-facebook"></i>
-          </a>
-        </div>
-
-        <p id="footer-logo-text">The AAS WorldWide Telescope project has been supported by:</p>
-
-        <div id="logos">
-          <img class="footer-logo" src="{{ rel_top ~ 'assets/aas-publishing-71582561158855.png' }}">
-          <img class="footer-logo" src="{{ rel_top ~ 'assets/nsf-logo-white.png' }}">
-          <img class="footer-logo" src="{{ rel_top ~ 'assets/dotnetfoundationhorizontal.svg' }}">
-          <img class="footer-logo" src="{{ rel_top ~ 'assets/moore-logo-white.png' }}">
-          <img class="footer-logo" src="{{ rel_top ~ 'assets/microsoft-dark.png' }}">
-        </div>
-      </footer>
-    </div>
-  </body>
 </html>


### PR DESCRIPTION
Update the link to the beta installer, adding a simple registration form so that we can reach out to the people that actually install and use the beta. Also add some disclaimers for people who should be careful about installing the beta in production systems.