### PR TITLE
content/download/beta.md: update for 6.0.904.0

### DIFF
--- a/content/download/beta.md
+++ b/content/download/beta.md
@@ -1,5 +1,5 @@
 +++
-date = 2022-01-04
+date = 2022-01-05
 title = "WWT Downloads: Registered Beta"
 aliases = ["/Download/Beta"]
 
@@ -9,7 +9,7 @@ titlebox_class = "background-19036"
 
 Thank you for your interest in helping beta-test the next version of AAS
 WorldWide Telescope for Windows! The latest beta release version is
-**6.0.902.0** (Jan 4, 2022; [technical changelog][cl]).
+**6.0.904.0** (Jan 5, 2022; [technical changelog][cl]).
 
 [cl]: https://github.com/WorldWideTelescope/wwt-windows-client/blob/release/WWTExplorer3d/CHANGELOG.md
 


### PR DESCRIPTION
Skipping 6.0.903.0 because I need to produce two versions in order to test out the auto-update functionality, and there's nothing useful gained by logging both versions separately.