### PR TITLE
Update the "front door" email address to hello@worldwidetelescope.org

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-base_url = "//worldwidetelescope.org/"
+base_url = "https://worldwidetelescope.org/"
 title = "WorldWide Telescope"
 description = "WorldWide Telescope is a tool for showcasing astronomical data and knowledge."
 default_language = "en"
@@ -7,7 +7,7 @@ highlight_code = true
 build_search_index = false
 
 [slugify]
-paths = "safe"  # Preserve capitalization
+paths = "safe" # Preserve capitalization
 
 [extra]
 github_url = "https://github.com/WorldWideTelescope/wwt-user-website"

--- a/content/connect.md
+++ b/content/connect.md
@@ -37,7 +37,7 @@ We also invite you to follow WWT on social media platforms like [Twitter],
 [Facebook]: https://facebook.com/wwtelescope
 
 If none of these public channels is quite right for your inquiry, you can
-always email the WWT leadership at <wwt@aas.org>.
+send an email to <hello@worldwidetelescope.org>.
 
 
 # Events
@@ -62,7 +62,7 @@ The <b>WWT Code of Conduct</b> spells out the ground rules for participation
 in WWT events and forums. The bottom line: don’t be a jerk.
 {% end %}
 
-{% card(text="Contact WWT", url="mailto:wwt@aas.org", html=1) %}
+{% card(text="Report a Conduct Issue", url="https://numfocus.typeform.com/to/ynjGdT", html=1) %}
 If some aspect of your participation in WWT has made you feel uncomfortable or
 unwelcome, please reach out to NumFOCUS.
 {% end %}

--- a/content/learn/who-uses.md
+++ b/content/learn/who-uses.md
@@ -47,4 +47,4 @@ WWT!
 [“What is *Chandra* Doing Now?”]: http://chandraobservatory.herokuapp.com/
 [WWT Ambassadors]: https://wwtambassadors.org/
 
-Reach out to WWT leadership at <wwt@aas.org> to be added to the list!
+Reach out to the WWT community at <hello@worldwidetelescope.org> to be added to the list!

--- a/content/use/researchers.md
+++ b/content/use/researchers.md
@@ -71,11 +71,4 @@ reusable TypeScript library. With a little web development elbow grease you
 can build your own custom web interactives.
 {% end %}
 
-{% card(text="Beta Inquiry", url="mailto:wwt@aas.org", html=1) %}
-We are currently beta-testing support for easily creating WWT <a
-href="https://journals.aas.org/landing/interactive-figures-201909/"><b>interactive
-figures</b></a> in publications. If that sounds interesting to you, get in
-touch to learn more!
-{% end %}
-
 </section>


### PR DESCRIPTION
Yet another part of the sponsorship migration.

Related pull requests cross-linked at: https://github.com/WorldWideTelescope/worldwidetelescope.github.io/pull/88