### PR TITLE
Add links to more interactives and update educators page

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -17,6 +17,8 @@ The WWT ecosystem includes a [Windows application][windows-client], an
 [pywwt]: https://pywwt.readthedocs.io/
 [webgl]: https://docs.worldwidetelescope.org/webgl-reference/latest/
 
+# See What's Possible
+
 <section class="flex-cards">
 
 {% card(text="Compare Hubble and Webb in WWT!", url="https://web.wwtassets.org/specials/2023/cosmicds-carina/", html=1, targetblank=1) %}
@@ -25,6 +27,22 @@ The WWT ecosystem includes a [Windows application][windows-client], an
 
 {% card(text="Explore other beautiful JWST images", url="https://web.wwtassets.org/specials/2023/jwst-aas241/", html=1, targetblank=1) %}
 <b>Dozens more JWST images await you!</b> They’re all in WWT.
+{% end %}
+
+{% card(text="Explore the nova in WWT", url="https://projects.cosmicds.cfa.harvard.edu/blaze-star-nova/", html=1, targetblank=1) %}
+<b>Preview the upcoming nova and learn how to find it in the sky!</b> WWT makes it possible.
+{% end %}
+
+{% card(text="Learn about the Radcliffe Wave", url="https://projects.cosmicds.cfa.harvard.edu/radwave-in-motion/", html=1, targetblank=1) %}
+<b>Discover the oscillating Radcliffe Wave!</b> Using WWT, it can be viewed in both 2D and 3D.
+{% end %}
+
+{% card(text="Revisit the eclipse", url="https://projects.cosmicds.cfa.harvard.edu/solar-eclipse-2024/", html=1, targetblank=1) %}
+<b>Want to revisit the solar eclipse?</b> WWT lets you see how it looked all over the world!
+{% end %}
+
+{% card(text="To the Moon!", url="https://web.wwtassets.org/specials/2021/iotmn/", html=1, targetblank=1) %}
+<b>Interested in the Moon?</b> Explore five different lunar imagesets using WWT.
 {% end %}
 
 </section>

--- a/content/home.md
+++ b/content/home.md
@@ -17,6 +17,19 @@ The WWT ecosystem includes a [Windows application][windows-client], an
 [pywwt]: https://pywwt.readthedocs.io/
 [webgl]: https://docs.worldwidetelescope.org/webgl-reference/latest/
 
+
+# Get Started with WWT
+
+{% videoteaser(lbid="intro", img="../assets/video-thumbnail.jpg", ytid="CD_W6wJp26E") %}
+<ul>
+  <li><i><a href="#intro">Watch the trailer</a> for a video introduction.</i></li>
+  <li><i>Got Python? Check out our
+    cloud-based <a href="https://pywwt.readthedocs.io/en/stable/#quick-start">Jupyter notebooks</a>.</i></li>
+  <li><i><a href="/webclient/">Launch the WWT web client</a>!</i></li>
+</ul>
+{% end %}
+
+
 # See What's Possible
 
 <section class="flex-cards">
@@ -46,18 +59,6 @@ The WWT ecosystem includes a [Windows application][windows-client], an
 {% end %}
 
 </section>
-
-
-# Get Started with WWT
-
-{% videoteaser(lbid="intro", img="../assets/video-thumbnail.jpg", ytid="CD_W6wJp26E") %}
-<ul>
-  <li><i><a href="#intro">Watch the trailer</a> for a video introduction.</i></li>
-  <li><i>Got Python? Check out our
-    cloud-based <a href="https://pywwt.readthedocs.io/en/stable/#quick-start">Jupyter notebooks</a>.</i></li>
-  <li><i><a href="/webclient/">Launch the WWT web client</a>!</i></li>
-</ul>
-{% end %}
 
 
 # Something for Everyone

--- a/content/home.md
+++ b/content/home.md
@@ -58,6 +58,8 @@ The WWT ecosystem includes a [Windows application][windows-client], an
 <b>Interested in the Moon?</b> Explore five different lunar imagesets using WWT.
 {% end %}
 
+For more astronomical interactives powered by WWT, check out <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">Cosmic Data Stories</a>.
+
 </section>
 
 

--- a/content/use/educators.md
+++ b/content/use/educators.md
@@ -26,6 +26,12 @@ that use WWT to transform classroom astronomy education:
 
 </section>
 
+This video gives an overview of a [Cosmic Data Story][cosmicds-eclipse] focused on the 2024 Total Solar Eclipse:
+
+{{ youtube(id="DzXVy_99Ldg", class="youtube-embed") }}
+
+[cosmicds-eclipse]: https://projects.cosmicds.cfa.harvard.edu/solar-eclipse-2024/
+
 Here’s a video overview of the WWTA [ThinkSpace Seasons Lab][thinkspace-seasons]:
 
 [thinkspace-seasons]: https://wwtambassadors.org/thinkspace

--- a/content/use/educators.md
+++ b/content/use/educators.md
@@ -26,7 +26,7 @@ that use WWT to transform classroom astronomy education:
 
 </section>
 
-This video gives an overview of a [Cosmic Data Story][cosmicds-eclipse] focused on the 2024 Total Solar Eclipse:
+This video gives an overview of a Cosmic Data Story [focused on the 2024 Total Solar Eclipse][cosmicds-eclipse]:
 
 {{ youtube(id="DzXVy_99Ldg", class="youtube-embed") }}
 

--- a/content/use/educators.md
+++ b/content/use/educators.md
@@ -10,14 +10,21 @@ titlebox_class = "background-19023"
 WorldWide Telescope empowers learners of all ages to explore the universe
 interactively and in three dimensions. Not only is this cool, it’s effective!
 But you don’t have to take our word for it — check out the materials and
-research of the [WWT Ambassadors][ambassadors] (WWTA) program, an effort based
-at the [Center for Astrophysics | Harvard & Smithsonian][cfa] that uses WWT to
-transform classroom astronomy education:
+research of the [Cosmic Data Stories][cosmicds] (CosmicDS) and [WWT Ambassadors][ambassadors]
+(WWTA) programs. These are both efforts based at the [Center for Astrophysics | Harvard & Smithsonian][cfa]
+that use WWT to transform classroom astronomy education:
 
+[cosmicds]: https://www.cosmicds.cfa.harvard.edu/
 [ambassadors]: https://wwtambassadors.org/
 [cfa]: https://www.cfa.harvard.edu/
 
-{{ bigbutton(text="Go to the WWTA homepage", url="https://wwtambassadors.org/") }}
+<section class="flex-buttons">
+
+{{ bigbutton(text="CosmicDS homepage", url="https://www.cosmicds.cfa.harvard.edu/") }}
+
+{{ bigbutton(text="WWTA homepage", url="https://wwtambassadors.org/") }}
+
+</section>
 
 Here’s a video overview of the WWTA [ThinkSpace Seasons Lab][thinkspace-seasons]:
 

--- a/sass/_content.scss
+++ b/sass/_content.scss
@@ -219,3 +219,10 @@ a {
     outline: none;
   }
 }
+
+// Flex container for the educator page buttons
+.flex-buttons {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+}

--- a/sass/_content.scss
+++ b/sass/_content.scss
@@ -119,6 +119,7 @@ body {
       p {
         margin: 0 0 1rem 0;
         flex-grow: 1;
+        text-align: center;
       }
 
       img {


### PR DESCRIPTION
This PR adds some more content to the user website, particularly to the section with interactives and the educators page.

On the main page, this adds a links to a few more interactives to show off what can be made with WWT. In particular these are three more Data Stories (the Carina one is already there) along with the moon interactive that we made a couple of years back. 

On the educators page, this updates the top paragraph to mention CosmicDS, adds a button to link to the homepage, and adds a video overview (of our solar eclipse story) to go along with the WWTA video.